### PR TITLE
fix(#37): pass multi-line commits to github output

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - fix-tags-multiline-commit
 
 jobs:
   tag:


### PR DESCRIPTION
multi-line commits are real